### PR TITLE
Bug fix, comments added, tests included

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -4,53 +4,154 @@
 # the generated `output` should be the same as `test/expected_output`
 
 import os
+import sys
+import json
 import logging
-import jinja2
+
+from jinja2 import FileSystemLoader, Environment
 
 log = logging.getLogger(__name__)
 
 
-def list_files(folder_path):
-    for name in os.listdir(folder_path):
+'''
+    Creates a directory if it doesn't exist.
+    In case the output will need to be written in a new directory,
+    that directory needs to be created.
+
+    @input: folder_name
+    @return: -
+'''
+def create_folder(folder_name):
+    if not os.path.exists(folder_name):
+        try:
+            os.makedirs(folder_name)
+        except:
+            print('Can not create output folder')
+            sys.exit()
+
+
+'''
+    Provides the .rst files paths in the current directory that can be used
+    in order to generate html files.
+
+    @input: current directory
+    @output: path to the .rst files
+'''
+def list_files(input_folder):
+    for name in os.listdir(input_folder):
         base, ext = os.path.splitext(name)
+
+        # Check for right file extension
         if ext != '.rst':
             continue
-        yield os.path.join(folder_path, name)
 
-def read_file(file_path):
-    with open(file_path, 'rb') as f:
-        raw_metadata = ""
-        for line in f:
-            if line.strip() == '---':
-                break
-            raw_metadata += line
-        content = ""
-        for line in f:
-            content += line
-    return json.loads(raw_metadata), content
+        yield os.path.join(input_folder, name)
 
-def write_output(name, html):
-    # TODO should not use sys.argv here, it breaks encapsulation
-    with open(os.path.join(sys.argv[2], name+'.html')) as f:
+
+'''
+    Reads an rst file and provides the metadata and content for the
+    curent file.
+
+    @input: path to file
+    @output: metadata, content
+'''
+def read_metadata_content(input_file):
+    # Build metadata json object
+    raw_metadata = ""
+    metadata = None
+
+    for line in input_file:
+
+        # End of metadata details found, content starts with the next line
+        if line.strip() == '---':
+
+            # If no metadata processed, return a blank json object
+            metadata = json.loads(raw_metadata) if raw_metadata else None
+            break
+
+        raw_metadata += line
+
+    # Build content string
+    content = ""
+    for line in input_file:
+        content += line
+
+    # Blank lines are not relevant in rst files
+    content = content.strip()
+
+    return metadata, content
+
+
+'''
+    Open file by accessing the path to the file and returns
+    the metadata and the content
+
+    @input: file_path
+    @output: metadata, content
+'''
+def read_rst_file(file_path):
+    with open(file_path, 'r') as f:
+        return read_metadata_content(f)
+
+
+'''
+    Write html page to a file.
+
+    @input: output_file, html code
+    @return: -
+'''
+def write_output(output_file, html):
+    with open(output_file, "w") as f:
         f.write(html)
 
-def generate_site(folder_path):
-    log.info("Generating site from %r", folder_path)
-    jinja_env = jinja2.Environment(loader=FileSystemLoader(folder_path + 'layout'))
-    for file_path in list_files(folder_path):
-        metadata, content = read_file(file_path)
-        template_name = metadata['template']
+
+'''
+    Generate website from static files.
+    
+    @input: directory where the website is stored
+    @output: -
+'''
+def generate_site(input_folder, output_folder):
+    log.info("Generating site from %r", input_folder)
+
+    # Create the jinja2 environment from the html files stored locally
+    jinja_env = Environment(loader=FileSystemLoader(input_folder + 'layout'),
+                            lstrip_blocks=True, trim_blocks=True)
+
+    for file_path in list_files(input_folder):
+
+        # Process current file and obtain the needed template
+        metadata, content = read_rst_file(file_path)
+        if metadata is None:
+            continue
+
+        template_name = metadata['layout']
         template = jinja_env.get_template(template_name)
+
+        # Render data using the template
         data = dict(metadata, content=content)
-        html = template(**data)
-        write_output(name, html)
-        log.info("Writing %r with template %r", name, template_name)
+        html = template.render(data)
+
+        # Write the result in an html file
+        file_name = os.path.splitext(os.path.basename(file_path))[0]
+        output_file = os.path.join(output_folder, file_name + '.html')
+        write_output(output_file, html)
+        log.info("Writing %r with template %r", file_name, template_name)
 
 
-def main():
-    generate_site(sys.argv[1])
+def main(input_folder, output_folder):
+    create_folder(output_folder)
+    generate_site(input_folder, output_folder)
 
 
 if __name__ == '__main__':
     logging.basicConfig()
-    main()
+
+    if len(sys.argv) < 3:
+        print("Run like this: ./generate.py test/source output")
+        sys.exit()
+
+    input_folder = sys.argv[1]
+    output_folder = sys.argv[2]
+
+    main(input_folder, output_folder)

--- a/test/source/unittest/nometadata.rst
+++ b/test/source/unittest/nometadata.rst
@@ -1,0 +1,3 @@
+---
+
+Write an email to contact@example.com.

--- a/test/test_generate.py
+++ b/test/test_generate.py
@@ -1,0 +1,107 @@
+import os
+
+from generate import *
+from unittest import mock, TestCase
+
+
+class TestGenerate(TestCase):
+
+    '''
+        Open three content files for testing functionalities.
+    '''
+    def open_content_files(self, mode):
+        file1 = open('content1.txt', mode)
+        file2 = open('content2.txt', mode)
+        file3 = open('content3.txt', mode)
+
+        return file1, file2, file3
+
+    '''
+    	Delete the files when the tests end.
+    '''
+    def delete_content_files(self):
+        os.remove("content1.txt")
+        os.remove("content2.txt")
+        os.remove("content3.txt")
+
+    '''
+    	Create three content files for testing functionalities.
+    '''
+    def create_content_files(self):
+        metadata = '''{"title": "Contact us!", "layout": "base.html"}
+		---
+		'''
+
+        content1 = '''Write an email to contact@example.com.'''
+        content2 = '''
+
+		Write an email to contact@example.com.'''
+
+        content3 = '''
+
+
+		Write an email to contact@example.com.
+
+
+		'''
+
+        file1, file2, file3 = self.open_content_files('w')
+        file1.write(metadata + content1)
+        file2.write(metadata + content2)
+        file3.write(metadata + content3)
+        file1.close()
+        file2.close()
+        file3.close()
+
+    '''
+    	Check that the output folder will be created by mocking the call.
+    '''
+    @mock.patch('generate.generate_site')
+    @mock.patch('generate.create_folder')
+    def test_output_folder_created(self, create_folder_mock, generate_site_mock):
+        main(None, 'my_test_output')
+
+        assert create_folder_mock.called
+        assert generate_site_mock.called
+
+    '''
+    	Check that the not relevant files (according to the rst documentation)
+    	are not taken into account. If the content section starts or ends with
+    	blank lines, those will be removed.
+    '''
+    def test_blank_lines_removed(self):
+        self.create_content_files()
+
+        file1, file2, file3 = self.open_content_files('r')
+
+        m1, c1 = read_metadata_content(file1)
+        m2, c2 = read_metadata_content(file2)
+        m3, c3 = read_metadata_content(file3)
+
+        file1.close()
+        file2.close()
+        file3.close()
+        self.delete_content_files()
+
+        assert c1 == c2 == c3
+
+    '''
+    	Check that if no metadata details are provided, no output file is created.
+    '''
+    @mock.patch('generate.write_output')
+    def test_no_output_file_for_empty(self, write_output_mock):
+        write_output_mock.return_value = False
+
+        generate_site('test\\source\\unittest', None)
+        assert not write_output_mock.called
+
+    '''
+    	Check that for each rst file in our current working environment,
+    	a call to write the corresponding html file was made.
+    '''
+    @mock.patch('generate.write_output')
+    def test_create_output_files(self, write_output_mock):
+        write_output_mock.return_value = False
+
+        generate_site('test\\source\\', 'output')
+        assert write_output_mock.call_count == 2


### PR DESCRIPTION
Solved the task and fixed the bugs according to the requirements:

- the input file was changed from text to binary inside the reading function
- the output directory is created if it doesn't exist
- the blank lines are removed from the beginning/end of the rst file (according to the documentation)
- the template call was changed to use the render method

For the Environment object, I added the lstrip_blocks=True, trim_blocks=True parameters such that the blank lines in the template won't be displayed. I still had issues with generating the exact same output and saw different solutions related to jinja2 mentioning the template requires '{%-' rather than '{%' when the optional fields are not filled in. I was not sure this was the solution, as I remember you mentioning the only bugs are inside the python file, but I couldn't find the issue with not generating the exact same output and still displaying some blank lines. This issue did not allow me to add tests that compared the expected output directory with the generated output.

The tests created by me use pytest with the following use cases:
- the same text is generated for content having blank lines before/after the actual content
- no output file is written on the disk when no metadata exists
- the output directory is always created
- the write file method is called 2 times as 2 rst files exist in the directory. The follow up would have been comparing the output with the expected output, but faced the blank lines issue.